### PR TITLE
BUG FIX: Update process.py

### DIFF
--- a/mobileposer/process.py
+++ b/mobileposer/process.py
@@ -111,7 +111,7 @@ def process_amass():
             b += l
 
         print("Saving...")
-        print(out_vacc.shape, out_pose.shape)
+        # print(out_vacc.shape, out_pose.shape)
         data = {
             'joint': out_joint,
             'pose': out_pose,


### PR DESCRIPTION
commented out print(out_vacc.shape, out_pose.shape) at line 114 because out_vacc and out_pose are lists, not Tensor. if you let them be as they are, they give some errors like the below: 
```
$ ~/root/workspace/mobileposer/# python process.py --dataset amass
Reading ACCAD
100%|████████████████████████████████████████████████████████████████████████████████████████| 252/252 [00:00<00:00, 283.52it/s]
Synthesizing IMU accelerations and orientations
100%|█████████████████████████████████████████████████████████████████████████████████████████| 252/252 [00:09<00:00, 26.05it/s]
Saving...
Traceback (most recent call last):
  File "/root/workspace/mobileposer/process.py", line 358, in <module>
    process_amass()
  File "/root/workspace/mobileposer/process.py", line 114, in process_amass
    print(out_vacc.shape, out_pose.shape)
AttributeError: 'list' object has no attribute 'shape'
```