### PR TITLE
BUG FIX: accidental commented-out torch.save(data, data_path) in process.py

### DIFF
--- a/mobileposer/process.py
+++ b/mobileposer/process.py
@@ -122,7 +122,7 @@ def process_amass():
             'contact': out_contact
         }
         data_path = paths.processed_datasets / f"{ds_name}.pt"
-        #torch.save(data, data_path)
+        torch.save(data, data_path)
         print(f"Synthetic AMASS dataset is saved at: {data_path}")
 
 


### PR DESCRIPTION
it looks torch.save(data, data_path) in process_amass function is commented out but it's necessary to save the preprocessed dataset, right?